### PR TITLE
Add notation toggle

### DIFF
--- a/src/main/java/com/sets/discremathsets/domain/Set.java
+++ b/src/main/java/com/sets/discremathsets/domain/Set.java
@@ -1,7 +1,8 @@
 package com.sets.discremathsets.domain;
 
+import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class Set {
@@ -91,7 +92,7 @@ public class Set {
     public String toString() {
         StringBuilder setFormat = new StringBuilder();
         setFormat.append("{");
-        setFormat.append(set.stream().collect(Collectors.joining(", ")));
+        setFormat.append(String.join(", ", set));
         setFormat.append("}");
         return setFormat.toString();
     }

--- a/src/main/java/com/sets/discremathsets/logic/Controller.java
+++ b/src/main/java/com/sets/discremathsets/logic/Controller.java
@@ -1,6 +1,7 @@
 package com.sets.discremathsets.logic;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -26,9 +27,25 @@ public class Controller {
     public Label DifferenceAMinusBResultLabel;
     public Label DifferenceBMinusALabel;
     public Label DifferenceBMinusAResultLabel;
+    public CheckBox notationToggle;
 
+    // Instance variable to check whether current mode is set relations or not. True by default
+    private boolean modeIsSetRelations = true;
 
+    // Instance variables to check the set relations of the two current sets. False by default.
+    private boolean notationToggled = false;
+    private boolean setsAreEqual = false;
+    private boolean setsAreEquivalent = false;
+    private boolean setAIsSubsetOfB = false;
+    private boolean setBIsSubsetOfA = false;
+    private boolean setsAreDisjoint = false;
+
+    // Get set from the text field
     private HashSet<String> getSetFromTextField(TextField setField) {
+        if (setField.getText().isEmpty()) {
+            return new HashSet<>();
+        }
+
         String[] elements = setField.getText().split(",");
         HashSet<String> set = new HashSet<>();
 
@@ -40,6 +57,87 @@ public class Controller {
         return set;
     }
 
+    // Updates labels of set relations depending on whether notation is toggled
+    private void updateSetRelations() {
+        if (!notationToggled) {
+            if (setsAreEqual) {
+                isEqualOrUnionLabel.setText("Equal Sets: ✔");
+            } else {
+                isEqualOrUnionLabel.setText("Equal Sets: ✘");
+            }
+
+            if (setsAreEquivalent) {
+                isEquivalentOrUnionResultLabel.setText("Equivalent Sets: ✔");
+            } else {
+                isEquivalentOrUnionResultLabel.setText("Equivalent Sets: ✘");
+            }
+
+            if (setAIsSubsetOfB) {
+                isASubsetOfBOrIntersectionLabel.setText("A is a subset of B: ✔");
+            } else {
+                isASubsetOfBOrIntersectionLabel.setText("A is a subset of B: ✘");
+            }
+
+            if (setBIsSubsetOfA) {
+                isBSubsetOfAOrIntersectionResultLabel.setText("B is a subset of A: ✔");
+            } else {
+                isBSubsetOfAOrIntersectionResultLabel.setText("B is a subset of A: ✘");
+            }
+
+            if (setsAreDisjoint) {
+                isDisjointOrDifferenceAMinusBLabel.setText("Disjoint Sets: ✔");
+            } else {
+                isDisjointOrDifferenceAMinusBLabel.setText("Disjoint Sets: ✘");
+            }
+        } else {
+            if (setsAreEqual) {
+                isEqualOrUnionLabel.setText("A = B");
+            } else {
+                isEqualOrUnionLabel.setText("A ≠ B");
+            }
+
+            if (setsAreEquivalent) {
+                isEquivalentOrUnionResultLabel.setText("A ≈ B");
+            } else {
+                isEquivalentOrUnionResultLabel.setText("A ≉ B");
+            }
+
+            if (setAIsSubsetOfB) {
+                isASubsetOfBOrIntersectionLabel.setText("A ⊂ B");
+            } else {
+                isASubsetOfBOrIntersectionLabel.setText("A ⊄ B");
+            }
+
+            if (setBIsSubsetOfA) {
+                isBSubsetOfAOrIntersectionResultLabel.setText("B ⊂ A");
+            } else {
+                isBSubsetOfAOrIntersectionResultLabel.setText("B ⊄ A");
+            }
+
+            if (setsAreDisjoint) {
+                isDisjointOrDifferenceAMinusBLabel.setText("A ∩ B = ∅");
+            } else {
+                isDisjointOrDifferenceAMinusBLabel.setText("A ∩ B ≠ ∅");
+            }
+        }
+    }
+
+    // Updates labels of set operations depending on whether notation is toggled
+    private void updateSetOperations() {
+        if (!notationToggled) {
+            isEqualOrUnionLabel.setText("A Union B");
+            isASubsetOfBOrIntersectionLabel.setText("A Intersection B");
+            isDisjointOrDifferenceAMinusBLabel.setText("A Minus B");
+            DifferenceBMinusALabel.setText("B Minus A");
+        } else {
+            isEqualOrUnionLabel.setText("A ∪ B");
+            isASubsetOfBOrIntersectionLabel.setText("A ∩ B");
+            isDisjointOrDifferenceAMinusBLabel.setText("A - B");
+            DifferenceBMinusALabel.setText("B - A");
+        }
+    }
+
+    // Runs when "Get Set Relations" or "Get Set Operations" button is clicked
     @FXML
     protected void onResultsButtonClick() {
         // Create sets from the text field
@@ -47,103 +145,96 @@ public class Controller {
         Set setB = new Set(getSetFromTextField(setBField));
 
         // Output text from text field
-        setAOutput.setText(String.valueOf(setA));
-        setBOutput.setText(String.valueOf(setB));
+        if (setA.isEmpty()) {
+            setAOutput.setText("∅");
+        } else {
+            setAOutput.setText(String.valueOf(setA));
+        }
 
-        if (resultsButton.getText().equals("Get Set Relations")) {
+        if (setB.isEmpty()) {
+            setBOutput.setText("∅");
+        } else {
+            setBOutput.setText(String.valueOf(setB));
+        }
+
+        if (modeIsSetRelations) {
             // SET RELATIONS
-            if (setA.isEqualTo(setB)) {
-                isEqualOrUnionLabel.setText("Equal Sets: ✔");
-            } else {
-                isEqualOrUnionLabel.setText("Equal Sets: ✘");
-            }
-
-            if (setA.isEquivalentTo(setB)) {
-                isEquivalentOrUnionResultLabel.setText("Equivalent Sets: ✔");
-            } else {
-                isEquivalentOrUnionResultLabel.setText("Equivalent Sets: ✘");
-            }
-
-            if (setA.isSubsetOf(setB)) {
-                isASubsetOfBOrIntersectionLabel.setText("A is a subset of B: ✔");
-            } else {
-                isASubsetOfBOrIntersectionLabel.setText("A is a subset of B: ✘");
-            }
-
-            if (setB.isSubsetOf(setA)) {
-                isBSubsetOfAOrIntersectionResultLabel.setText("B is a subset of A: ✔");
-            } else {
-                isBSubsetOfAOrIntersectionResultLabel.setText("B is a subset of A: ✘");
-            }
-
-            if (setA.isDisjoint(setB)) {
-                isDisjointOrDifferenceAMinusBLabel.setText("Disjoint Sets: ✔");
-            } else {
-                isDisjointOrDifferenceAMinusBLabel.setText("Disjoint Sets: ✘");
-            }
+            setsAreEqual = setA.isEqualTo(setB);
+            setsAreEquivalent = setA.isEquivalentTo(setB);
+            setAIsSubsetOfB = setA.isSubsetOf(setB);
+            setBIsSubsetOfA = setB.isSubsetOf(setA);
+            setsAreDisjoint = setA.isDisjoint(setB);
+            updateSetRelations();
         } else {
             // SET OPERATIONS
+            updateSetOperations();
             Set setUnion = new Set(setA.union(setB));
             Set setIntersection = new Set(setA.intersection(setB));
             Set setDifferenceAMinusB = new Set(setA.difference(setB));
             Set setDifferenceBMinusA = new Set(setB.difference(setA));
 
             if (setUnion.isEmpty()) {
-                isEquivalentOrUnionResultLabel.setText("∅");
+                isEquivalentOrUnionResultLabel.setText("= ∅");
             } else {
                 isEquivalentOrUnionResultLabel.setText("= " + setUnion);
             }
 
             if (setIntersection.isEmpty()) {
-                isBSubsetOfAOrIntersectionResultLabel.setText("∅");
+                isBSubsetOfAOrIntersectionResultLabel.setText("= ∅");
             } else {
                 isBSubsetOfAOrIntersectionResultLabel.setText("= " + setIntersection);
             }
 
             if (setDifferenceAMinusB.isEmpty()) {
-                DifferenceAMinusBResultLabel.setText("∅");
+                DifferenceAMinusBResultLabel.setText("= ∅");
             } else {
                 DifferenceAMinusBResultLabel.setText("= " + setDifferenceAMinusB);
             }
 
             if (setDifferenceBMinusA.isEmpty()) {
-                DifferenceBMinusAResultLabel.setText("∅");
+                DifferenceBMinusAResultLabel.setText("= ∅");
             } else {
                 DifferenceBMinusAResultLabel.setText("= " + setDifferenceBMinusA);
             }
         }
     }
 
-    // Toggle between Set Relations and Set Operations
+    // Toggles between Set Relations and Set Operations
     @FXML
     protected void onToggleButtonClick() {
-        if (resultsButton.getText().equals("Get Set Relations")) {
+        if (modeIsSetRelations) {
+            modeIsSetRelations = false;
             resultsButton.setText("Get Set Operations");
             toggleButton.setText("Switch to Set Relations");
 
-            isEqualOrUnionLabel.setText("A Union B");
-            isEquivalentOrUnionResultLabel.setText("= ∅");
-            isASubsetOfBOrIntersectionLabel.setText("A Intersection B");
-            isBSubsetOfAOrIntersectionResultLabel.setText(" = ∅");
-            isDisjointOrDifferenceAMinusBLabel.setText("A Minus B");
+            onResultsButtonClick();
 
             DifferenceAMinusBResultLabel.setVisible(true);
             DifferenceBMinusALabel.setVisible(true);
             DifferenceBMinusAResultLabel.setVisible(true);
 
         } else {
+            modeIsSetRelations = true;
             resultsButton.setText("Get Set Relations");
             toggleButton.setText("Switch to Set Operations");
 
-            isEqualOrUnionLabel.setText("Equal Sets: ✘");
-            isEquivalentOrUnionResultLabel.setText("Equivalent Sets: ✘");
-            isASubsetOfBOrIntersectionLabel.setText("A is a subset of B: ✘");
-            isBSubsetOfAOrIntersectionResultLabel.setText("B is a subset of A: ✘");
-            isDisjointOrDifferenceAMinusBLabel.setText("Disjoint Sets: ✘");
+            onResultsButtonClick();
 
             DifferenceAMinusBResultLabel.setVisible(false);
             DifferenceBMinusALabel.setVisible(false);
             DifferenceBMinusAResultLabel.setVisible(false);
+        }
+    }
+
+    // Toggle between words and notation
+    @FXML
+    protected void onNotationToggle() {
+        notationToggled = notationToggle.isSelected();
+
+        if (modeIsSetRelations) {
+            updateSetRelations();
+        } else {
+            updateSetOperations();
         }
     }
 }

--- a/src/main/resources/com/sets/discremathsets/window-view.fxml
+++ b/src/main/resources/com/sets/discremathsets/window-view.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Separator?>
 <?import javafx.scene.control.TextField?>
@@ -87,6 +88,11 @@
                <font>
                   <Font size="15.0" />
                </font></Label>
+            <CheckBox fx:id="notationToggle" mnemonicParsing="false" onAction="#onNotationToggle" text="Toggle Notation">
+               <VBox.margin>
+                  <Insets left="120.0" top="40.0" />
+               </VBox.margin>
+            </CheckBox>
          </children>
          <opaqueInsets>
             <Insets />


### PR DESCRIPTION
- Added notation toggle to be able to see set notation theory instead of just words (ex. **A ⊂ B** instead of A is a subset of B).
- Toggling between Set Relations and Set Operations will now automatically update the results.
- Fixed a bug where trying to get results with one set being an empty set results in the set having a single comma on the set output label.